### PR TITLE
Set with righthand expressions introduced

### DIFF
--- a/stmt_test.go
+++ b/stmt_test.go
@@ -293,3 +293,26 @@ func TestBindStruct(t *testing.T) {
 	require.Equal(t, []interface{}{2}, q.Args())
 	require.EqualValues(t, []interface{}{&u.ID, &u.Date, &u.ChildTime, &u.Name}, q.Dest())
 }
+
+func TestRightHandUpdate(t *testing.T) {
+	sqlf := sqlf.PostgreSQL
+
+	exp := "UPDATE lists SET arr=arr || $1"
+	q := sqlf.Update("lists").
+		Set("arr = arr || ?", 42)
+	require.Equal(t, exp, q.String())
+	require.Equal(t, []interface{}{42}, q.Args())
+}
+
+func TestRightHandInsert(t *testing.T) {
+	sqlf := sqlf.PostgreSQL
+
+	exp := "INSERT INTO g ( a, b ) VALUES ( $1, ST_Distance($2, $3) )"
+	q := sqlf.
+		InsertInto("g").
+		Set("a", 42).
+		Set("b = ST_Distance(?, ?)", "{geom1}", "{geom2}")
+
+	require.Equal(t, exp, q.String())
+	require.Equal(t, []interface{}{42, "{geom1}", "{geom2}"}, q.Args())
+}


### PR DESCRIPTION
Hey,

Good library, and although we've had good times with it, we also ran into this issue of not being able to set righthand expressions in `Set` all around the place. I'm talking about `InsertInto` and `Update` too. This commit adds a reverse-compatible capability to use the following construct:

```go
sqlf.SetDialect(sqlf.PostgreSQL)
// this is something very common in postgis, basically
stmt := sqlf.InsertInto("geodata").
	Set("geom = ST_GeomFromGeoJSON(?)", geoJSON)
```

Producing the following SQL:

```sql
INSERT INTO geodata ( geom ) VALUES ( ST_GeomFromGeoJSON($1) )
```

Hopefully, this helps to bring the library to parity with SQL expressibility.

Best regards,
@tucnak

P.S. What's your position on `JOIN LATERAL` and similar JOIN subqueries?

```sql
SELECT a.*, bar
FROM table
LEFT JOIN LATERAL (
	SELECT json_agg(foo) as bar
	FROM other_table
	GROUP BY id
) b ON true
```

How would I write said query in sqlf, and if I couldn't, would you welcome a change that would enable me to?