### PR TITLE
use savsgio gotils strconv

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.16
+	github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38
 	github.com/stretchr/testify v1.8.2
 	github.com/valyala/bytebufferpool v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,13 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
 github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38 h1:D0vL7YNisV2yqE55+q0lFuGse6U8lxlg7fYTctlT5Gc=
+github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38/go.mod h1:sM7Mt7uEoCeFSCBM+qBrqvEo+/9vdmj19wzp3yzUhmg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/util.go
+++ b/util.go
@@ -1,7 +1,7 @@
 package sqlf
 
 import (
-	"unsafe"
+	"github.com/savsgio/gotils/strconv"
 )
 
 func insertAt(dest, src []interface{}, index int) []interface{} {
@@ -23,5 +23,5 @@ func insertAt(dest, src []interface{}, index int) []interface{} {
 // Use the returned string with care, make sure to never use it after
 // the ByteBuffer is deallocated or returned to a pool.
 func bufToString(buf *[]byte) string {
-	return *(*string)(unsafe.Pointer(buf))
+	return strconv.B2S(*buf)
 }


### PR DESCRIPTION
Hello

I know this trick to convert from slice of bytes to string without allocation, used a lot in fasthttp and other projects,

https://groups.google.com/g/Golang-Nuts/c/ENgbUzYvCuU/m/90yGx7GUAgAJ

however, since go 1.2O things changed and many projects had to update using build tags based on go version. The package github.com/savsgio/gotils/strconv already did it for us

I think this can be a safe alternative to this project

BTW, on dialect.go there is another usage of unsafe package with atomic.StorePointer. Today the recommentatios is to use [atomic.Pointer](https://pkg.go.dev/sync/atomic#Pointer.Store) but it requires go 1.19

And I think this could be a great code improvement, maybe I can add it on a separated PR