### PR TITLE
use atomic.Pointer[T] instead unsafe pointers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.17.0' # The Go version to download (if necessary) and use.
+        go-version: '1.19.0' # The Go version to download (if necessary) and use.
 
     # Install all the dependencies
     - name: Install dependencies

--- a/cache_test.go
+++ b/cache_test.go
@@ -11,13 +11,13 @@ func TestSQLCache(t *testing.T) {
 	defer putBuffer(buf)
 
 	buf.WriteString("test")
-	_, ok := defaultDialect.getCachedSQL(buf)
+	_, ok := defaultDialectPointer.Load().getCachedSQL(buf)
 	require.False(t, ok)
 
-	defaultDialect.putCachedSQL(buf, "test SQL")
-	sql, ok := defaultDialect.getCachedSQL(buf)
+	defaultDialectPointer.Load().putCachedSQL(buf, "test SQL")
+	sql, ok := defaultDialectPointer.Load().getCachedSQL(buf)
 	require.True(t, ok)
 	require.Equal(t, "test SQL", sql)
 
-	defaultDialect.ClearCache()
+	defaultDialectPointer.Load().ClearCache()
 }

--- a/dialect.go
+++ b/dialect.go
@@ -4,8 +4,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
-	"unsafe"
 )
 
 // Dialect defines the method SQL statement is to be built.
@@ -40,7 +38,7 @@ var (
 	PostgreSQL *Dialect = &Dialect{}
 )
 
-var defaultDialect = NoDialect
+var defaultDialectPointer = newAtomicPointer(NoDialect)
 
 /*
 SetDialect selects a Dialect to be used by default.
@@ -50,7 +48,7 @@ Dialect can be one of sqlf.NoDialect or sqlf.PostgreSQL
 	sqlf.SetDialect(sqlf.PostgreSQL)
 */
 func SetDialect(newDefaultDialect *Dialect) {
-	atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&defaultDialect)), unsafe.Pointer(newDefaultDialect))
+	defaultDialectPointer.Store(newDefaultDialect)
 }
 
 /*

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,15 @@
 module github.com/leporo/sqlf
 
-go 1.13
+go 1.19
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/stretchr/testify v1.8.2
 	github.com/valyala/bytebufferpool v1.0.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/stmt.go
+++ b/stmt.go
@@ -26,7 +26,7 @@ Use New for special cases like this:
 	}
 */
 func New(verb string, args ...interface{}) *Stmt {
-	return defaultDialect.New(verb, args...)
+	return defaultDialectPointer.Load().New(verb, args...)
 }
 
 /*
@@ -43,7 +43,7 @@ From starts a SELECT statement.
 	}
 */
 func From(expr string, args ...interface{}) *Stmt {
-	return defaultDialect.From(expr, args...)
+	return defaultDialectPointer.Load().From(expr, args...)
 }
 
 /*
@@ -51,7 +51,7 @@ With starts a statement prepended by WITH clause
 and closes a subquery passed as an argument.
 */
 func With(queryName string, query *Stmt) *Stmt {
-	return defaultDialect.With(queryName, query)
+	return defaultDialectPointer.Load().With(queryName, query)
 }
 
 /*
@@ -70,7 +70,7 @@ Select starts a SELECT statement.
 Note that From method can also be used to start a SELECT statement.
 */
 func Select(expr string, args ...interface{}) *Stmt {
-	return defaultDialect.Select(expr, args...)
+	return defaultDialectPointer.Load().Select(expr, args...)
 }
 
 /*
@@ -85,7 +85,7 @@ Update starts an UPDATE statement.
 	}
 */
 func Update(tableName string) *Stmt {
-	return defaultDialect.Update(tableName)
+	return defaultDialectPointer.Load().Update(tableName)
 }
 
 /*
@@ -101,7 +101,7 @@ InsertInto starts an INSERT statement.
 	}
 */
 func InsertInto(tableName string) *Stmt {
-	return defaultDialect.InsertInto(tableName)
+	return defaultDialectPointer.Load().InsertInto(tableName)
 }
 
 /*
@@ -110,7 +110,7 @@ DeleteFrom starts a DELETE statement.
 	err := sqlf.DeleteFrom("table").Where("id = ?", id).ExecAndClose(ctx, db)
 */
 func DeleteFrom(tableName string) *Stmt {
-	return defaultDialect.DeleteFrom(tableName)
+	return defaultDialectPointer.Load().DeleteFrom(tableName)
 }
 
 type stmtChunk struct {

--- a/util.go
+++ b/util.go
@@ -1,6 +1,7 @@
 package sqlf
 
 import (
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -24,4 +25,12 @@ func insertAt(dest, src []interface{}, index int) []interface{} {
 // the ByteBuffer is deallocated or returned to a pool.
 func bufToString(buf *[]byte) string {
 	return *(*string)(unsafe.Pointer(buf))
+}
+
+func newAtomicPointer[T any](initialValue *T) *atomic.Pointer[T] {
+	var pointer atomic.Pointer[T]
+
+	pointer.Store(initialValue)
+
+	return &pointer
 }


### PR DESCRIPTION
as I mention on https://github.com/leporo/sqlf/pull/14 this PR uses the new atomic api available since go 1.19 instead use unsafe pointers.

also, this is a big improvement since the original code uses atomic operations to write to the pointer, but the code does not uses atomic operations to read, so it is an optimistic approach but it is not really thread safe. Now each operation use atomics and I think the performance impact is minimal (if not, we can wrap the pointer in a structure that uses a RW mutex). I run the benchmarks before and after, you can see the results below

unfortunately this requires go 1.19 and this may be not a problem since the latest stable go version at this moment is go 1.23.4

if you decided to merge https://github.com/leporo/sqlf/pull/13 first, then the go version matrix should be updated to not run tests on older go versions

```console
oos: linux
goarch: amd64
pkg: github.com/leporo/sqlf
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
                              │   old.txt    │               new.txt                │
                              │    sec/op    │    sec/op     vs base                │
SelectDontClose-8               1.236µ ± ∞ ¹   1.607µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Select-8                        149.7n ± ∞ ¹   153.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectPg-8                      150.1n ± ∞ ¹   151.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
ManyFields-8                    1.958µ ± ∞ ¹   1.843µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Bind-8                          637.9n ± ∞ ¹   668.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
ManyFieldsPg-8                  1.974µ ± ∞ ¹   2.128µ ± ∞ ¹       ~ (p=1.000 n=1) ²
MixedOrder-8                    156.1n ± ∞ ¹   171.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
BuildPg-8                       24.96n ± ∞ ¹   25.13n ± ∞ ¹       ~ (p=1.000 n=1) ²
Build-8                         26.89n ± ∞ ¹   25.53n ± ∞ ¹       ~ (p=1.000 n=1) ²
Dest-8                          111.4n ± ∞ ¹   115.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectComplex-8                 527.6n ± ∞ ¹   517.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectComplexPg-8               532.7n ± ∞ ¹   612.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectSubqueryFmt-8             1.141µ ± ∞ ¹   1.140µ ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectSubqueryFmtPostgreSQL-8   1.107µ ± ∞ ¹   1.183µ ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectSubquery-8                488.9n ± ∞ ¹   480.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectSubqueryPostgreSQL-8      484.7n ± ∞ ¹   630.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
With-8                          653.4n ± ∞ ¹   644.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
In-8                            487.3n ± ∞ ¹   502.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                         374.9n         394.0n        +5.08%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                              │   old.txt   │               new.txt               │
                              │    B/op     │    B/op      vs base                │
SelectDontClose-8               624.0 ± ∞ ¹   624.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
Select-8                        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectPg-8                      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
ManyFields-8                    0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
Bind-8                          24.00 ± ∞ ¹   24.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
ManyFieldsPg-8                  0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
MixedOrder-8                    0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
BuildPg-8                       0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
Build-8                         0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
Dest-8                          0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectComplex-8                 0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectComplexPg-8               0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectSubqueryFmt-8             112.0 ± ∞ ¹   112.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectSubqueryFmtPostgreSQL-8   112.0 ± ∞ ¹   112.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectSubquery-8                0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectSubqueryPostgreSQL-8      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
With-8                          0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
In-8                            0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                   ³                +0.00%               ³
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ summaries must be >0 to compute geomean

                              │   old.txt   │               new.txt               │
                              │  allocs/op  │  allocs/op   vs base                │
SelectDontClose-8               9.000 ± ∞ ¹   9.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
Select-8                        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectPg-8                      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
ManyFields-8                    0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
Bind-8                          3.000 ± ∞ ¹   3.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
ManyFieldsPg-8                  0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
MixedOrder-8                    0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
BuildPg-8                       0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
Build-8                         0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
Dest-8                          0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectComplex-8                 0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectComplexPg-8               0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectSubqueryFmt-8             2.000 ± ∞ ¹   2.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectSubqueryFmtPostgreSQL-8   2.000 ± ∞ ¹   2.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectSubquery-8                0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
SelectSubqueryPostgreSQL-8      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
With-8                          0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
In-8                            0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                   ³                +0.00%               ³
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ summaries must be >0 to compute geomean
```